### PR TITLE
build: Update pr-reviewer image's registry name.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,4 +9,4 @@ runs:
   # this is built using GCB by building the Dockerfile in this directory on
   # every tagged release.  After tagging a release, a new version should
   # automatically appear.
-  image: 'docker://gcr.io/kubebuilder/pr-verifier:v0.4.3'
+  image: 'docker://registry.k8s.io/kubebuilder/pr-verifier:v0.4.3'


### PR DESCRIPTION
Change pr-reviewr's image registry from gcr.io to registry.k8s.io.

All new pr-verifier images will get pushed to new registry. Every SIG using this artifact will need update it accordingly.